### PR TITLE
compat_resource transient dependency

### DIFF
--- a/nuodbawsquickstart/templates/init.py
+++ b/nuodbawsquickstart/templates/init.py
@@ -20,7 +20,8 @@ git_repos = {"nuodb": "https://github.com/nuodb/nuodb-chef.git",
              "apt": "https://github.com/chef-cookbooks/apt.git",
              "java": "https://github.com/socrata-cookbooks/java",
              "yum-epel": "https://github.com/chef-cookbooks/yum-epel.git",
-             "yum": "https://github.com/chef-cookbooks/yum"
+             "yum": "https://github.com/chef-cookbooks/yum",
+             "compat_resource": "https://github.com/chef-cookbooks/compat_resource"
              }
 for repo in git_repos:
   commands.append("if [ ! -d /var/chef/cookbooks/%s ]; then git clone %s /var/chef/cookbooks/%s; fi;" % (repo, git_repos[repo], repo))


### PR DESCRIPTION
**yum-epel** has dependency to **compat_resource** that should be installed as well.
Without it we will have next error(took from chef.log): 
```
[2017-05-17T07:58:51+00:00] WARN: *****************************************
[2017-05-17T07:58:51+00:00] WARN: Did not find config file: /etc/chef/solo.rb, using command line options.
[2017-05-17T07:58:51+00:00] WARN: *****************************************
[2017-05-17T07:58:51+00:00] WARN: *****************************************
[2017-05-17T07:58:51+00:00] WARN: Did not find config file: /etc/chef/client.rb, using command line options.
[2017-05-17T07:58:51+00:00] WARN: *****************************************
Starting Chef Client, version 13.0.118
resolving cookbooks for run list: ["nuodb"]

================================================================================
Error Resolving Cookbooks for Run List:
================================================================================

Missing Cookbooks:
------------------
No such cookbook: compat_resource

Expanded Run List:
------------------
* nuodb

System Info:
------------
chef_version=13.0.118
platform=amazon
platform_version=2017.03
ruby=ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
program_name=chef-solo worker: ppid=25342;start=07:58:51;
executable=/opt/chef/bin/chef-solo


Running handlers:
[2017-05-17T07:58:52+00:00] ERROR: Running exception handlers
Running handlers complete
[2017-05-17T07:58:52+00:00] ERROR: Exception handlers complete
Chef Client failed. 0 resources updated in 00 seconds
```